### PR TITLE
Remove invalid ORCID and ROR

### DIFF
--- a/idranges.toml
+++ b/idranges.toml
@@ -66,5 +66,5 @@ v4c-bc = "https://example.org/voc4cat_biocatalysis/"
 first_id = 1
 last_id = 200
 gh_name = "markdoerr"
-orcid = "0000-0001-2345-9999"
-ror_id = "https://ror.org/999"
+orcid = ""
+ror_id = ""


### PR DESCRIPTION
ORCID and ROR are validated and they have in integrated checksum value. So inventing arbitrary values will lead to validation errors as observed in #2.